### PR TITLE
EOS Compatibility and 5.4 updates

### DIFF
--- a/Source/Private/OnlineIdentityInterfacePlayFab.cpp
+++ b/Source/Private/OnlineIdentityInterfacePlayFab.cpp
@@ -262,9 +262,12 @@ void FOnlineIdentityPlayFab::Tick(float DeltaTime)
 				User->GetUserAttribute(USER_ATTR_ID, PlatformUserIdStr);
 				UsersToAuth.Add(PlatformUserIdStr);
 			}
-//#if defined(OSS_PLAYFAB_WIN64) || defined(OSS_PLAYFAB_PLAYSTATION)
-//			AutoLogin(0);
-//#endif
+#if defined(OSS_PLAYFAB_WIN64) || defined(OSS_PLAYFAB_PLAYSTATION)
+			if (OSSPlayFab->bForceAutoLoginOnTick)
+			{
+				AutoLogin(0);
+			}
+#endif
 			bAuthAllUsers = false;
 		}
 	}

--- a/Source/Private/OnlineIdentityInterfacePlayFab.cpp
+++ b/Source/Private/OnlineIdentityInterfacePlayFab.cpp
@@ -205,13 +205,13 @@ void FOnlineIdentityPlayFab::RevokeAuthToken(const FUniqueNetId& UserId, const F
 	}
 }
 
-void FOnlineIdentityPlayFab::GetUserPrivilege(const FUniqueNetId& UserId, EUserPrivileges::Type Privilege, const FOnGetUserPrivilegeCompleteDelegate& Delegate)
+void FOnlineIdentityPlayFab::GetUserPrivilege(const FUniqueNetId& LocalUserId, EUserPrivileges::Type Privilege, const FOnGetUserPrivilegeCompleteDelegate& Delegate, EShowPrivilegeResolveUI ShowResolveUI)
 {
 	UE_LOG_ONLINE_IDENTITY(Verbose, TEXT("FOnlineIdentityPlayFab::GetUserPrivilege"));
 
 	OSS_PLAYFAB_GET_NATIVE_IDENTITY_INTERFACE
 	{
-		NativeIdentityInterface->GetUserPrivilege(UserId, Privilege, Delegate);
+		NativeIdentityInterface->GetUserPrivilege(UserId, Privilege, Delegate, ShowResolveUI);
 	}
 }
 

--- a/Source/Private/OnlineIdentityInterfacePlayFab.cpp
+++ b/Source/Private/OnlineIdentityInterfacePlayFab.cpp
@@ -211,7 +211,7 @@ void FOnlineIdentityPlayFab::GetUserPrivilege(const FUniqueNetId& LocalUserId, E
 
 	OSS_PLAYFAB_GET_NATIVE_IDENTITY_INTERFACE
 	{
-		NativeIdentityInterface->GetUserPrivilege(UserId, Privilege, Delegate, ShowResolveUI);
+		NativeIdentityInterface->GetUserPrivilege(LocalUserId, Privilege, Delegate, ShowResolveUI);
 	}
 }
 

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -97,6 +97,7 @@ bool FOnlineSubsystemPlayFab::Init()
 	GConfig->GetInt(TEXT("OnlineSubsystemPlayFab"), TEXT("MaxEndpointsPerDeviceCount"), MaxEndpointsPerDeviceCount, GEngineIni);
 	GConfig->GetInt(TEXT("OnlineSubsystemPlayFab"), TEXT("MaxUserCount"), MaxUserCount, GEngineIni);
 	GConfig->GetInt(TEXT("OnlineSubsystemPlayFab"), TEXT("MaxUsersPerDeviceCount"), MaxUsersPerDeviceCount, GEngineIni);
+	GConfig->GetBool(TEXT("OnlineSubsystemPlayFab"), TEXT("bForceAutoLoginOnTick"), bForceAutoLoginOnTick, GEngineIni);
 	ParseDirectPeerConnectivityOptions();
 
 	TSharedPtr<IPlugin> SocketsPlugin = IPluginManager::Get().FindPlugin(TEXT("PlayFabParty"));

--- a/Source/Public/OnlineIdentityInterfacePlayFab.h
+++ b/Source/Public/OnlineIdentityInterfacePlayFab.h
@@ -124,7 +124,8 @@ public:
 	virtual FString GetPlayerNickname(const FUniqueNetId& UserId) const override;
 	virtual FString GetAuthToken(int32 LocalUserNum) const override;
 	virtual void RevokeAuthToken(const FUniqueNetId& UserId, const FOnRevokeAuthTokenCompleteDelegate& Delegate) override;
-	virtual void GetUserPrivilege(const FUniqueNetId& UserId, EUserPrivileges::Type Privilege, const FOnGetUserPrivilegeCompleteDelegate& Delegate) override;
+	// virtual void GetUserPrivilege(const FUniqueNetId& UserId, EUserPrivileges::Type Privilege, const FOnGetUserPrivilegeCompleteDelegate& Delegate) override;
+	virtual void GetUserPrivilege(const FUniqueNetId& LocalUserId, EUserPrivileges::Type Privilege, const FOnGetUserPrivilegeCompleteDelegate& Delegate, EShowPrivilegeResolveUI ShowResolveUI = EShowPrivilegeResolveUI::Default) override;
 	virtual FPlatformUserId GetPlatformUserIdFromUniqueNetId(const FUniqueNetId& UniqueNetId) const override;
 	virtual FString GetAuthType() const override;
 

--- a/Source/Public/OnlineSubsystemPlayFab.h
+++ b/Source/Public/OnlineSubsystemPlayFab.h
@@ -164,6 +164,7 @@ public:
 	int32 MaxEndpointsPerDeviceCount = 1;
 	int32 MaxUserCount = 8;
 	int32 MaxUsersPerDeviceCount = 1;
+	bool bForceAutoLoginOnTick = true;
 	PartyDirectPeerConnectivityOptions DirectPeerConnectivityOptions 
 		= PartyDirectPeerConnectivityOptions::AnyPlatformType | PartyDirectPeerConnectivityOptions::AnyEntityLoginProvider;
 


### PR DESCRIPTION
When using with EOS, it's problematic to keep calling AutoLogin on Tick. It will be automatically called by EOS and the setting allow us to configure it separately. If not added, the setting allows the default behavior.